### PR TITLE
Added support for maximumSize setting.

### DIFF
--- a/DMSplitViewExample/DMSplitView/DMSplitView.m
+++ b/DMSplitViewExample/DMSplitView/DMSplitView.m
@@ -293,9 +293,7 @@
 	}
 	
 	CGFloat minimumSize = constraintShrinkingSubview.minSize;
-    CGFloat maximumSize = (constraintGrowingSubview.maxSize == 0) ? INT_MAX : constraintGrowingSubview.maxSize;
-	CGFloat finalCoordinate = fmin(currentCoordinate + (shrinkingSize - minimumSize), maximumSize);
-    return finalCoordinate;
+    return (constraintGrowingSubview.maxSize == 0) ? currentCoordinate + (shrinkingSize - minimumSize) : constraintGrowingSubview.maxSize;
 }
 
 - (void)splitView:(NSSplitView *)splitView resizeSubviewsWithOldSize:(NSSize)oldSize {


### PR DESCRIPTION
Hey,

I noticed that the maximumSize settings for the split view were being ignored when dragging the divider around. I've added support for that by modifying the constrainMaxCoordinate function to either take the full width or the maximum width that has been set.
